### PR TITLE
used req.query for fragment requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+# [3.9.5] - 06-08-2018
+### Fixed
+- Fragment get requests should use query from `req.query` to include changes on `req.query` object.
+
 # [3.9.3] - 06-08-2018
 ### Added
 - `originalurl` key added to fragment

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puzzle-microfrontends",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "logo": "https://image.ibb.co/jM29on/puzzlelogo.png",

--- a/src/fragment.ts
+++ b/src/fragment.ts
@@ -9,6 +9,7 @@ import path from "path";
 import {container, TYPES} from "./base";
 import {Logger} from "./logger";
 import {decompress} from "iltorb";
+import {Request, Response} from 'express';
 import {HttpClient} from "./client";
 
 
@@ -183,7 +184,7 @@ export class FragmentStorefront extends Fragment {
    * @param req
    * @returns {Promise<IFragmentContentResponse>}
    */
-  async getContent(attribs: any = {}, req?: { url: string, headers: { [name: string]: string } }): Promise<IFragmentContentResponse> {
+  async getContent(attribs: any = {}, req?: Request): Promise<IFragmentContentResponse> {
     if (!this.config) {
       logger.error(new Error(`No config provided for fragment: ${this.name}`));
       return {
@@ -206,10 +207,10 @@ export class FragmentStorefront extends Fragment {
 
     if (req) {
       if (req.url) {
-        parsedRequest = url.parse(req.url, true) as { pathname: string, query: object };
+        parsedRequest = url.parse(req.url) as { pathname: string };
         query = {
           ...query,
-          ...parsedRequest.query,
+          ...req.query,
         };
       }
       if (req.headers) {


### PR DESCRIPTION
# [3.9.5] - 06-08-2018
### Fixed
- Fragment get requests should use query from `req.query` to include changes on `req.query` object.